### PR TITLE
Introduction of a list provider to support more flexibility at implementations

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ pages:
     - Setup: setup.md
     - Configuration: configuration.md
     - Subscriber Provider: subscriber-provider.md
+    - List Provider: list-provider.md
     - Usage: usage.md
     - Webhook: webhook.md
     - Tests: tests.md

--- a/src/Command/SynchronizeMergeFieldsCommand.php
+++ b/src/Command/SynchronizeMergeFieldsCommand.php
@@ -5,6 +5,8 @@ namespace Welp\MailchimpBundle\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Welp\MailchimpBundle\Provider\ListProviderInterface;
 
 class SynchronizeMergeFieldsCommand extends ContainerAwareCommand
 {
@@ -15,20 +17,28 @@ class SynchronizeMergeFieldsCommand extends ContainerAwareCommand
             ->setName('welp:mailchimp:synchronize-merge-fields')
             // @TODO add params : listId
         ;
-    }
+    } 
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln(sprintf('<info>%s</info>', $this->getDescription()));
 
-        $lists = $this->getContainer()->getParameter('welp_mailchimp.lists');
-        if (sizeof($lists) == 0) {
-            throw new \RuntimeException("No Mailchimp list has been defined. Check the your config.yml file based on MailchimpBundle's README.md");
+        $listProviderKey = $this->getContainer()->getParameter('welp_mailchimp.list_provider');
+        try {
+            $listProvider = $this->getContainer()->get($listProviderKey); 
+        } catch (ServiceNotFoundException $e) {
+            throw new \InvalidArgumentException(sprintf('List Provider "%s" should be defined as a service.', $listProviderKey), $e->getCode(), $e);
         }
 
-        foreach ($lists as $listId => $listParameters) {
+        if (!$listProvider instanceof ListProviderInterface) {
+            throw new \InvalidArgumentException(sprintf('List Provider "%s" should implement Welp\MailchimpBundle\Provider\ListProviderInterface.', $listProviderKey));
+        }
+
+        $lists = $listProvider->getLists();
+
+        foreach ($lists as $list) {
             $this->getContainer()->get('welp_mailchimp.list_synchronizer')
-                ->synchronizeMergeFields($listId, $listParameters['merge_fields']);
+                ->synchronizeMergeFields($list->getListId(), $list->getMergeFields());
             ;
         }
     }

--- a/src/Command/SynchronizeSubscribersCommand.php
+++ b/src/Command/SynchronizeSubscribersCommand.php
@@ -44,8 +44,7 @@ class SynchronizeSubscribersCommand extends ContainerAwareCommand
 
         if (!$listProvider instanceof ListProviderInterface) {
             throw new \InvalidArgumentException(sprintf('List Provider "%s" should implement Welp\MailchimpBundle\Provider\ListProviderInterface.', $listProviderKey));
-        }
-        
+        }       
 
         $lists = $listProvider->getLists();
         

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,6 +25,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('api_key')
                     ->isRequired()
                 ->end()
+                ->scalarNode('list_provider')
+                    ->defaultValue('welp_mailchimp.list_provider')
+                ->end()
                 // lists
                 ->arrayNode('lists')
                     ->useAttributeAsKey('listId')

--- a/src/DependencyInjection/WelpMailchimpExtension.php
+++ b/src/DependencyInjection/WelpMailchimpExtension.php
@@ -14,6 +14,7 @@ class WelpMailchimpExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
         $container->setParameter('welp_mailchimp.lists', $config['lists']);
+        $container->setParameter('welp_mailchimp.list_provider',$config['list_provider']);    
         $container->setParameter('welp_mailchimp.api_key', isset($config['api_key']) ? $config['api_key'] : null);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));

--- a/src/Provider/ConfigListProvider.php
+++ b/src/Provider/ConfigListProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Welp\MailchimpBundle\Provider;
+
+use Welp\MailchimpBundle\Provider\ListProviderInterface;
+use Welp\MailchimpBundle\Subscriber\SubscriberList;
+
+class ConfigListProvider implements ListProviderInterface
+{
+    private $providerFactory;
+    private $lists;
+
+    public function __construct(ProviderFactory $providerFactory, $lists)
+    {
+       $this->lists = $lists;
+       $this->providerFactory = $providerFactory;
+    }
+
+    /**
+     * Default list provider, retrieve the lists from the config file.
+     * {@inheritdoc}
+     */
+    public function getLists()
+    {
+        if (sizeof($this->lists) == 0) {
+            throw new \RuntimeException("No Mailchimp list has been defined. Check the your config.yml file based on MailchimpBundle's README.md");
+        }
+        $lists = array();
+        foreach ($this->lists as $listId => $listParameters) {
+            $providerServiceKey = $listParameters['subscriber_provider'];
+
+            $provider = $this->providerFactory->create($providerServiceKey);
+            $lists[] = new SubscriberList($listId, $provider);           
+        }
+
+        return $lists;
+    }
+}

--- a/src/Provider/ConfigListProvider.php
+++ b/src/Provider/ConfigListProvider.php
@@ -30,7 +30,10 @@ class ConfigListProvider implements ListProviderInterface
             $providerServiceKey = $listParameters['subscriber_provider'];
 
             $provider = $this->providerFactory->create($providerServiceKey);
-            $lists[] = new SubscriberList($listId, $provider, $listParameters['merge_fields']);           
+            $subscriberList = new SubscriberList($listId, $provider, $listParameters['merge_fields']);
+            $subscriberList->setWebhookUrl($listParameters['webhook_url']);
+            $subscriberList->setWebhookSecret($listParameters['webhook_secret']);
+            $lists[] = $subscriberList;            
         }
 
         return $lists;

--- a/src/Provider/ConfigListProvider.php
+++ b/src/Provider/ConfigListProvider.php
@@ -26,16 +26,42 @@ class ConfigListProvider implements ListProviderInterface
             throw new \RuntimeException("No Mailchimp list has been defined. Check the your config.yml file based on MailchimpBundle's README.md");
         }
         $lists = array();
-        foreach ($this->lists as $listId => $listParameters) {
-            $providerServiceKey = $listParameters['subscriber_provider'];
-
-            $provider = $this->providerFactory->create($providerServiceKey);
-            $subscriberList = new SubscriberList($listId, $provider, $listParameters['merge_fields']);
-            $subscriberList->setWebhookUrl($listParameters['webhook_url']);
-            $subscriberList->setWebhookSecret($listParameters['webhook_secret']);
-            $lists[] = $subscriberList;            
+        foreach ($this->lists as $listId => $listParameters) 
+        {            
+            $lists[] = $this->createList($listId, $listParameters);            
         }
-
         return $lists;
+    }
+
+    /**
+     * Default list provider, retrieve one list from the config file.
+     * {@inheritdoc}
+     */
+    public function getList($listId)
+    {
+        foreach ($this->lists as $id => $listParameters) 
+        {
+            if($id == $listId)
+            {
+                return $this->createList($id, $listParameters);
+            }
+        }
+    }
+    
+    /**
+     * create one SubscriberList
+     * @param string $listId
+     * @param string $listParameters
+     * @return SubscriberList 
+     */
+    private function createList($listId, $listParameters)
+    {
+        $providerServiceKey = $listParameters['subscriber_provider'];
+        $provider = $this->providerFactory->create($providerServiceKey);
+        $subscriberList = new SubscriberList($listId, $provider, $listParameters['merge_fields']);
+        $subscriberList->setWebhookUrl($listParameters['webhook_url']);
+        $subscriberList->setWebhookSecret($listParameters['webhook_secret']);
+
+        return $subscriberList;
     }
 }

--- a/src/Provider/ConfigListProvider.php
+++ b/src/Provider/ConfigListProvider.php
@@ -30,7 +30,7 @@ class ConfigListProvider implements ListProviderInterface
             $providerServiceKey = $listParameters['subscriber_provider'];
 
             $provider = $this->providerFactory->create($providerServiceKey);
-            $lists[] = new SubscriberList($listId, $provider);           
+            $lists[] = new SubscriberList($listId, $provider, $listParameters['merge_fields']);           
         }
 
         return $lists;

--- a/src/Provider/ListProviderInterface.php
+++ b/src/Provider/ListProviderInterface.php
@@ -3,19 +3,19 @@
 namespace Welp\MailchimpBundle\Provider;
 
 /**
- * Subscriber provider interface
+ * List provider interface
  */
 interface ListProviderInterface
 {
     /**
      * Get all the available Mailchimp lists
-     * @return array of SubscriberList
+     * @return array of SubscriberListInterface
      */
     public function getLists();
 
     /**
      * Get one Mailchimp list by id
-     * @return SubscriberList
+     * @return SubscriberListInterface
      */
     public function getList($listId);
 }

--- a/src/Provider/ListProviderInterface.php
+++ b/src/Provider/ListProviderInterface.php
@@ -12,4 +12,10 @@ interface ListProviderInterface
      * @return array of SubscriberList
      */
     public function getLists();
+
+    /**
+     * Get one Mailchimp list by id
+     * @return SubscriberList
+     */
+    public function getList($listId);
 }

--- a/src/Provider/ListProviderInterface.php
+++ b/src/Provider/ListProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Welp\MailchimpBundle\Provider;
+
+/**
+ * Subscriber provider interface
+ */
+interface ListProviderInterface
+{
+    /**
+     * Get all the available Mailchimp lists
+     * @return array of SubscriberList
+     */
+    public function getLists();
+}

--- a/src/Provider/ProviderFactory.php
+++ b/src/Provider/ProviderFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Welp\MailchimpBundle\Provider;
+
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Welp\MailchimpBundle\Provider\ProviderInterface;
+
+class ProviderFactory {
+
+    private $container;
+
+    public function __construct(ContainerInterface $container) {
+        $this->container = $container;
+    }
+
+    /**
+     * Get subscriber provider
+     * @param string $providerServiceKey
+     * @return ProviderInterface $provider
+     */
+    public function create($providerServiceKey) 
+    {
+        try {
+            $provider = $this->container->get($providerServiceKey);
+        } catch (ServiceNotFoundException $e) {
+            throw new \InvalidArgumentException(sprintf('Provider "%s" should be defined as a service.', $providerServiceKey), $e->getCode(), $e);
+        }
+
+        if (!$provider instanceof ProviderInterface) {
+            throw new \InvalidArgumentException(sprintf('Provider "%s" should implement Welp\MailchimpBundle\Provider\ProviderInterface.', $providerServiceKey));
+        }
+
+        return $provider;
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,6 +2,8 @@ parameters:
     welp_mailchimp.list_synchronizer_class: Welp\MailchimpBundle\Subscriber\ListSynchronizer
     welp_mailchimp.list_repository_class: Welp\MailchimpBundle\Subscriber\ListRepository
     welp_mailchimp.subscriber_listener_class: Welp\MailchimpBundle\Event\SubscriberListener
+    welp_mailchimp.provider_factory_class: Welp\MailchimpBundle\Provider\ProviderFactory
+    welp_mailchimp.config_list_provider_class: Welp\MailchimpBundle\Provider\ConfigListProvider
 
 services:
     # MailChimp
@@ -18,6 +20,17 @@ services:
         class: "%welp_mailchimp.list_synchronizer_class%"
         arguments:
             - '@welp_mailchimp.list_repository'
+    
+    welp_mailchimp.provider.factory:
+        class: "%welp_mailchimp.provider_factory_class%"
+        arguments:
+            - '@service_container'
+
+    welp_mailchimp.list_provider:
+        class: "%welp_mailchimp.config_list_provider_class%"
+        arguments:
+            - '@welp_mailchimp.provider.factory'
+            - '%welp_mailchimp.lists%'
 
     # Events
     welp_mailchimp.subscriber_listener:

--- a/src/Resources/doc/configuration.md
+++ b/src/Resources/doc/configuration.md
@@ -9,6 +9,7 @@ For each list you want to sync you must define a configuration in your `config.y
 ```yaml
 welp_mailchimp:
     api_key: YOURMAILCHIMPAPIKEY
+    list_provider: 'welp_mailchimp.list_provider'
     lists:
         listId1:
             # provider used in full synchronization

--- a/src/Resources/doc/index.md
+++ b/src/Resources/doc/index.md
@@ -5,7 +5,7 @@
 [![Packagist](https://img.shields.io/packagist/dt/welp/mailchimp-bundle.svg)](https://packagist.org/packages/welp/mailchimp-bundle)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/welpdev/mailchimp-bundle/master/LICENSE.md)
 
-This bundle will help you synchronise your project's newsletter subscribers into MailChimp throught MailChimp API V3.
+This bundle will help you synchronise your project's newsletter subscribers into MailChimp through MailChimp API V3.
 
 ## Features
 

--- a/src/Resources/doc/list-provider.md
+++ b/src/Resources/doc/list-provider.md
@@ -1,0 +1,100 @@
+# List Provider
+
+By default the list configuration is read from the `config.yml` when correctly defined according to [configuring your lists](configuration.md). This is done by the default list provider (`ConfigListProvider`). If you want to use a diffrent source for your list config you can create your own List Provider that should implement `Welp\MailChimpBundle\Provider\ListProviderInterface`.
+
+```php
+<?php
+
+namespace Welp\MailchimpBundle\Provider;
+
+/**
+ * List provider interface
+ */
+interface ListProviderInterface
+{
+    /**
+     * Get all the available Mailchimp lists
+     * @return array of SubscriberListInterface
+     */
+    public function getLists();
+
+    /**
+     * Get one Mailchimp list by id
+     * @return SubscriberListInterface
+     */
+    public function getList($listId);
+}
+```
+
+With your own implementation you could for example fetch your list configuration from Doctrine. 
+Example implementation:
+
+```php
+<?php
+
+namespace YourApp\App\Provider;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Welp\MailchimpBundle\Provider\ListProviderInterface;
+use Welp\MailchimpBundle\Subscriber\SubscriberListInterface;
+
+class DoctrineListProvider implements ListProviderInterface
+{
+
+    private $em;
+    private $listEntity;
+    private $userProvider;
+
+    public function __construct(EntityManagerInterface $entityManager, SubscriberListInterface $listEntity, $userProvider)
+    {
+        $this->em = $entityManager;
+        $this->listEntity = $listEntity;
+        $this->userProvider = $userProvider;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getList($listId)
+    {
+        $list = $this->em->getRepository($this->listEntity)->findOneByListId($listId);
+        $list->setProvider($this->userProvider);
+        return $list;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAll()
+    {
+        $lists = $this->em->getRepository($this->listEntity)->findAll();
+        foreach($lists as $list)
+        {
+            //add the provider to the list
+            $list->setProvider($this->userProvider);
+        }
+        return $lists;
+    }   
+}
+
+```
+
+Define your List provider as a service:
+
+```yaml
+doctrine.list.provider:
+    public: true
+    arguments:
+        - '@doctrine.orm.entity_manager'
+        - 'Welp\MailchimpBundle\Subscriber\SubscriberList'
+        - '@example_user_provider'
+```
+
+After this, don't forget to add the service key for your provider into your `config.yml`:
+
+```yaml
+    welp_mailchimp:
+        api_key: ...
+        list_provider: 'doctrine.list.provider'
+        ...
+```

--- a/src/Subscriber/ListSynchronizer.php
+++ b/src/Subscriber/ListSynchronizer.php
@@ -22,10 +22,10 @@ class ListSynchronizer
 
     /**
      * Synchronise user from provider with MailChimp List
-     * @param SubscriberList $list
+     * @param SubscriberListInterface $list
      * @return void
      */
-    public function synchronize(SubscriberList $list)
+    public function synchronize(SubscriberListInterface $list)
     {
         $listData = $this->listRepository->findById($list->getListId());
 

--- a/src/Subscriber/SubscriberList.php
+++ b/src/Subscriber/SubscriberList.php
@@ -22,14 +22,22 @@ class SubscriberList
     protected $provider;
 
     /**
+     * Merge fields
+     * @var array
+     */
+    protected $mergeFields;
+
+    /**
      *
      * @param string            $listId
      * @param ProviderInterface $provider
+     * @param array             $mergeFields
      */
-    public function __construct($listId, ProviderInterface $provider)
+    public function __construct($listId, ProviderInterface $provider, array $mergeFields = array())
     {
         $this->listId = $listId;
         $this->provider = $provider;
+        $this->mergeFields = $mergeFields;
     }
 
     /**
@@ -48,5 +56,14 @@ class SubscriberList
     public function getProvider()
     {
         return $this->provider;
+    }
+
+    /**
+     * Get the list merge fields
+     * @return array
+     */
+    public function getMergeFields()
+    {
+        return $this->mergeFields;
     }
 }

--- a/src/Subscriber/SubscriberList.php
+++ b/src/Subscriber/SubscriberList.php
@@ -29,6 +29,18 @@ class SubscriberList
     protected $mergeFields;
 
     /**
+     * MailChimp webhook URL
+     * @var string
+     */
+    protected $webhookUrl;
+    
+    /**
+     * MailChimp webhook secret
+     * @var string
+     */
+    protected $webhookSecret;
+
+    /**
      *
      * @param string            $listId
      * @param ProviderInterface $provider
@@ -71,5 +83,41 @@ class SubscriberList
     public function getMergeFields()
     {
         return $this->mergeFields;
+    }
+
+    /**
+     * Get the list webhook URL
+     * @return string
+     */
+    public function getWebhookUrl()
+    {
+        return $this->webhookUrl;
+    }
+
+    /**
+     * Set the list webhook URL
+     * @param string
+     */
+    public function setWebhookUrl($webhookUrl)
+    {
+        $this->webhookUrl = $webhookUrl;
+    }
+
+    /**
+     * Get the list webhook secret
+     * @return string
+     */
+    public function getWebhookSecret()
+    {
+        return $this->webhookSecret;
+    }
+
+    /**
+     * Set the list webhook secret
+     * @param string
+     */
+    public function setWebhookSecret($webhookSecret)
+    {
+        $this->webhookSecret = $webhookSecret;
     }
 }

--- a/src/Subscriber/SubscriberList.php
+++ b/src/Subscriber/SubscriberList.php
@@ -28,6 +28,18 @@ class SubscriberList
     protected $mergeFields;
 
     /**
+     * MailChimp webhook URL
+     * @var string
+     */
+    protected $webhookUrl;
+    
+    /**
+     * MailChimp webhook secret
+     * @var string
+     */
+    protected $webhookSecret;
+
+    /**
      *
      * @param string            $listId
      * @param ProviderInterface $provider
@@ -65,5 +77,41 @@ class SubscriberList
     public function getMergeFields()
     {
         return $this->mergeFields;
+    }
+
+    /**
+     * Get the list webhook URL
+     * @return string
+     */
+    public function getWebhookUrl()
+    {
+        return $this->webhookUrl;
+    }
+
+    /**
+     * Set the list webhook URL
+     * @param string
+     */
+    public function setWebhookUrl($webhookUrl)
+    {
+        $this->webhookUrl = $webhookUrl;
+    }
+
+    /**
+     * Get the list webhook secret
+     * @return string
+     */
+    public function getWebhookSecret()
+    {
+        return $this->webhookSecret;
+    }
+
+    /**
+     * Set the list webhook secret
+     * @param string
+     */
+    public function setWebhookSecret($webhookSecret)
+    {
+        $this->webhookSecret = $webhookSecret;
     }
 }

--- a/src/Subscriber/SubscriberList.php
+++ b/src/Subscriber/SubscriberList.php
@@ -8,7 +8,7 @@ use Welp\MailchimpBundle\Provider\DynamicProviderInterface;
 /**
  * SubscriberList linked a MailChimpList with a SubscriberProvider
  */
-class SubscriberList
+class SubscriberList implements SubscriberListInterface
 {
     /**
      * MailChimp ListId

--- a/src/Subscriber/SubscriberList.php
+++ b/src/Subscriber/SubscriberList.php
@@ -7,7 +7,7 @@ use Welp\MailchimpBundle\Provider\ProviderInterface;
 /**
  * SubscriberList linked a MailChimpList with a SubscriberProvider
  */
-class SubscriberList
+class SubscriberList implements SubscriberListInterface
 {
     /**
      * MailChimp ListId

--- a/src/Subscriber/SubscriberList.php
+++ b/src/Subscriber/SubscriberList.php
@@ -23,18 +23,27 @@ class SubscriberList
     protected $provider;
 
     /**
+     * Merge fields
+     * @var array
+     */
+    protected $mergeFields;
+
+    /**
      *
      * @param string            $listId
      * @param ProviderInterface $provider
+     * @param array             $mergeFields
      */
-    public function __construct($listId, ProviderInterface $provider)
+    public function __construct($listId, ProviderInterface $provider, array $mergeFields = array())
     {
         $this->listId = $listId;
         $this->provider = $provider;
+        $this->mergeFields = $mergeFields;
+
         //If the provider implements DynamicProviderInterface, set the list id in the provider
         if ($this->provider instanceof DynamicProviderInterface) {
             $this->provider->setListId($this->listId);
-        }
+        }        
     }
 
     /**
@@ -53,5 +62,14 @@ class SubscriberList
     public function getProvider()
     {
         return $this->provider;
+    }
+
+    /**
+     * Get the list merge fields
+     * @return array
+     */
+    public function getMergeFields()
+    {
+        return $this->mergeFields;
     }
 }

--- a/src/Subscriber/SubscriberListInterface.php
+++ b/src/Subscriber/SubscriberListInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Welp\MailchimpBundle\Subscriber;
+
+/**
+ * SubscriberList interface linked a MailChimpList with a SubscriberProvider
+ */
+interface SubscriberListInterface
+{
+    /**
+     * get the MailChimp ListId
+     * @return string
+     */
+    public function getListId();
+
+    /**
+     * Get the subscriber provider
+     * @return ProviderInterface
+     */
+    public function getProvider();
+
+    /**
+     * Get the list merge fields
+     * @return array
+     */
+    public function getMergeFields();
+
+    /**
+     * Get the list webhook URL
+     * @return string
+     */
+    public function getWebhookUrl();
+
+    /**
+     * Set the list webhook URL
+     * @param string
+     */
+    public function setWebhookUrl($webhookUrl);
+
+    /**
+     * Get the list webhook secret
+     * @return string
+     */
+    public function getWebhookSecret();
+
+    /**
+     * Set the list webhook secret
+     * @param string
+     */
+    public function setWebhookSecret($webhookSecret);
+}

--- a/tests/Provider/configListProviderTest.php
+++ b/tests/Provider/configListProviderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Welp\MailchimpBundle\Provider\ConfigListProvider;
+use Welp\MailchimpBundle\Subscriber\SubscriberList;
+
+class ConfigListProviderTest extends TestCase
+{
+    
+    protected $providerFactory = null;
+    protected $listConfig;
+
+    public function setUp()
+    {
+        $this->providerFactory = $this->createMock(\Welp\MailchimpBundle\Provider\ProviderFactory::class);   
+          
+        $this->providerFactory           
+            ->method('create')
+            ->will($this->returnValue($this->createMock(\Welp\MailchimpBundle\Provider\FosSubscriberProvider::class)))    
+        ;
+
+        $this->listConfig = array(
+            'sampleid' => array(
+                'subscriber_provider' => 'sample.provider',
+                'webhook_url' => 'url',
+                'webhook_secret' => 'secret',
+                'merge_fields' => array(
+                    array(
+                        'tag' => 'FNAME',
+                        'name' => 'First Name',
+                        'type'=> 'text',
+                        'public' => true
+                    ),
+                    array(
+                        'tag' => 'LNAME',
+                        'name' => 'Last Name',
+                        'type'=> 'text',
+                        'public' => true
+                    )
+                )
+            ),
+            'sampleid2' => array(
+                'subscriber_provider' => 'sample.provider',
+                'webhook_url' => 'url',
+                'webhook_secret' => 'secret',
+                'merge_fields' => array(
+                    array(
+                        'tag' => 'FNAME2',
+                        'name' => 'First Name',
+                        'type'=> 'text',
+                        'public' => true
+                    ),
+                    array(
+                        'tag' => 'LNAME2',
+                        'name' => 'Last Name',
+                        'type'=> 'text',
+                        'public' => true
+                    )
+                )
+            )
+        );
+    }
+
+    public function testGetListsEmpty()
+    {
+        //test with empty lists
+        $configListProvider = new ConfigListProvider($this->providerFactory, array());
+        $this->expectException(\RuntimeException::class);
+        $configListProvider->getLists();
+    }
+
+    public function testGetLists()
+    {
+               
+        $configListProvider = new ConfigListProvider($this->providerFactory, $this->listConfig);      
+        $lists = $configListProvider->getLists();
+
+        $this->assertEquals(2, count($lists));
+        $this->assertTrue($lists[0] instanceof SubscriberList);
+        $this->assertEquals("FNAME", $lists[0]->getMergeFields()[0]['tag']);
+    }
+
+    public function testGetList()
+    {
+               
+        $configListProvider = new ConfigListProvider($this->providerFactory, $this->listConfig);      
+        $list = $configListProvider->getList("sampleid2");
+
+        $this->assertTrue($list instanceof SubscriberList);
+        $this->assertEquals("sampleid2", $list->getListId());
+        $this->assertEquals("FNAME2", $list->getMergeFields()[0]['tag']);
+        $this->assertEquals("LNAME2", $list->getMergeFields()[01]['tag']);
+        $this->assertEquals("url", $list->getWebhookUrl());
+        $this->assertEquals("secret", $list->getWebhookSecret());
+    }
+
+   
+}


### PR DESCRIPTION
Hi,

I created a list provider interface that provides the list configuration (id, merge fields and webhook info).
Also added a default list provider that gets this info from the configuration parameters like before. 

In the process I added a provider factory that creates the provider service so the listProvider can make use of it.

With a (configurable) list provider one can use other sources for the list configuration like doctrine.
Please let me know what you think! 
