### PR TITLE
Fix for error when $errorResponse['body'] cannot be encoded

### DIFF
--- a/src/Subscriber/ListRepository.php
+++ b/src/Subscriber/ListRepository.php
@@ -514,7 +514,7 @@ class ListRepository
     private function throwMailchimpError(array $errorResponse)
     {
         $errorArray = json_decode($errorResponse['body'], true);
-        if (array_key_exists('errors', $errorArray)) {
+        if (is_array($errorArray) && array_key_exists('errors', $errorArray)) {
             throw new MailchimpException(
                 $errorArray['status'],
                 $errorArray['detail'],


### PR DESCRIPTION
Covered here: https://github.com/welpdev/mailchimp-bundle/issues/20 

Fix seems to be working fine for my situation