### PR TITLE
Configuration should use rootNode to avoid deprecations on symfony v4.3

### DIFF
--- a/spec/DependencyInjection/ConfigurationSpec.php
+++ b/spec/DependencyInjection/ConfigurationSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\Welp\MailchimpBundle\DependencyInjection;
+
+use PhpSpec\ObjectBehavior;
+
+class ConfigurationSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Welp\MailchimpBundle\DependencyInjection\Configuration');
+    }
+
+    function it_is_symfony_configuration()
+    {
+        $this->shouldImplement('Symfony\Component\Config\Definition\ConfigurationInterface');
+    }
+
+    function it_gets_config_tree_builder()
+    {
+        $this
+            ->getConfigTreeBuilder()
+            ->shouldHaveType('Symfony\Component\Config\Definition\Builder\TreeBuilder');
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,8 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('welp_mailchimp');
+        $treeBuilder = new TreeBuilder('welp_mailchimp');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('welp_mailchimp');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fixing the deprecation issue from #32 