### PR TITLE
fix: symfony 4.3 deprecation - #32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
     - '7.1'
 
 before_script:
-    - composer install --dev -v --prefer-source
+    - php -d memory_limit=-1 composer install --dev -v --prefer-source
 
 script:
     - bin/phpspec run -fpretty --verbose

--- a/spec/DependencyInjection/ConfigurationSpec.php
+++ b/spec/DependencyInjection/ConfigurationSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\Welp\MailchimpBundle\DependencyInjection;
+
+use PhpSpec\ObjectBehavior;
+
+class ConfigurationSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Welp\MailchimpBundle\DependencyInjection\Configuration');
+    }
+
+    function it_is_symfony_configuration()
+    {
+        $this->shouldImplement('Symfony\Component\Config\Definition\ConfigurationInterface');
+    }
+
+    function it_gets_config_tree_builder()
+    {
+        $this
+            ->getConfigTreeBuilder()
+            ->shouldHaveType('Symfony\Component\Config\Definition\Builder\TreeBuilder');
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,8 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('welp_mailchimp');
+        $treeBuilder = new TreeBuilder('welp_mailchimp');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('welp_mailchimp');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Trying to fix `A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.`